### PR TITLE
Use encoding conversion facilities from libxul via function pointers.

### DIFF
--- a/extensions/spellcheck/nuspell/glue/NuspellPortability.cpp
+++ b/extensions/spellcheck/nuspell/glue/NuspellPortability.cpp
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "mozilla/NuspellPortability.h"
+
+#include <string>
+#include <string_view>
+
+#include "mozilla/Encoding.h"
+#include "nsUTF8Utils.h"
+
+#include "utils.hxx"
+
+static const void*
+NuspellEncodingForLabelNoReplacement(std::string_view aLabel) {
+	return mozilla::Encoding::ForLabelNoReplacement(aLabel);
+}
+
+static bool NuspellUTF8ToUTF32(std::string_view aSrc, std::wstring& aDst) {
+	aDst.clear();
+	bool error = false;
+	const char* current = aSrc.data();
+	const char* end = current + aSrc.size();
+	while (current < end) {
+		uint32_t scalar = UTF8CharEnumerator::NextChar(&current, end, &error);
+		aDst.push_back(static_cast<wchar_t>(scalar));
+	}
+	return !error;
+}
+
+static bool
+NuspellEncodingToUTF32(const void* aEncoding, std::string_view aSrc, std::wstring& aDst) {
+	MOZ_ASSERT(aEncoding);
+	auto encoding = reinterpret_cast<const mozilla::Encoding*>(aEncoding);
+	if (aEncoding == UTF_8_ENCODING) {
+		return NuspellUTF8ToUTF32(aSrc, aDst);
+	}
+	nsDependentCString src(aSrc.data(), aSrc.size());
+	nsAutoCString dst;
+	nsresult rv = encoding->DecodeWithoutBOMHandling(src, dst);
+	MOZ_RELEASE_ASSERT(rv != NS_ERROR_OUT_OF_MEMORY);
+	mozilla::DebugOnly<bool> valid = NuspellUTF8ToUTF32(std::string_view(dst.BeginReading(), dst.Length()), aDst);
+	MOZ_ASSERT(valid);
+	return rv == NS_OK;
+}
+
+void mozilla::InitializeNuspellPortability() {
+	nuspell::initialize_portability(&NuspellEncodingForLabelNoReplacement,
+		                            &NuspellUTF8ToUTF32,
+		                            &NuspellEncodingToUTF32);
+}

--- a/extensions/spellcheck/nuspell/glue/NuspellPortability.h
+++ b/extensions/spellcheck/nuspell/glue/NuspellPortability.h
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_NuspellPortability_h
+#define mozilla_NuspellPortability_h
+
+namespace mozilla {
+
+void InitializeNuspellPortability();
+
+}; // namespace mozilla
+
+#endif // mozilla_NuspellPortability.h

--- a/extensions/spellcheck/nuspell/glue/moz.build
+++ b/extensions/spellcheck/nuspell/glue/moz.build
@@ -6,6 +6,7 @@
 
 UNIFIED_SOURCES += [
     'mozNuspell.cpp',
+    'NuspellPortability.cpp',
     'RemoteSpellCheckEngineChild.cpp',
     'RemoteSpellCheckEngineParent.cpp',
 ]
@@ -25,6 +26,7 @@ IPDL_SOURCES = [
 ]
 
 EXPORTS.mozilla += [
-     'RemoteSpellCheckEngineChild.h',
-     'RemoteSpellCheckEngineParent.h',
+    'NuspellPortability.h',
+    'RemoteSpellCheckEngineChild.h',
+    'RemoteSpellCheckEngineParent.h',
 ]

--- a/extensions/spellcheck/nuspell/src/utils.cxx
+++ b/extensions/spellcheck/nuspell/src/utils.cxx
@@ -27,13 +27,6 @@
 #include <unicode/unistr.h>
 #include <unicode/ustring.h>
 
-// The types are declared in utils.hxx. They should be declared
-// before including this header, and we inject their names with defines.
-#define ENCODING_RS_ENCODING nuspell::Encoding_rs
-#define ENCODING_RS_ENCODER nuspell::Encoder
-#define ENCODING_RS_DECODER nuspell::Decoder
-#include "encoding_rs.h"
-
 #if ' ' != 32 || '.' != 46 || 'A' != 65 || 'Z' != 90 || 'a' != 97 || 'z' != 122
 #error "Basic execution character set is not ASCII"
 #elif L' ' != 32 || L'.' != 46 || L'A' != 65 || L'Z' != 90 || L'a' != 97 ||    \
@@ -51,6 +44,19 @@ using namespace std;
 #define likely(expr) (expr)
 #define unlikely(expr) (expr)
 #endif
+
+static const void* (*encoding_for_label)(std::string_view label) = nullptr;
+static bool (*utf8_to_utf32)(std::string_view aSrc, std::wstring& aDst) = nullptr;
+static bool (*utf16_to_utf32)(std::u16string_view aSrc, std::wstring& aDst) = nullptr;
+static bool (*encoding_to_utf32)(const void* aEncoding, std::string_view aSrc, std::wstring& aDst) = nullptr;
+
+auto initialize_portability(const void* (*label_lookup)(std::string_view label),
+	                        bool (*convert_utf8)(std::string_view aSrc, std::wstring& aDst),
+	                        bool (*convert_encoding)(const void* aEncoding, std::string_view aSrc, std::wstring& aDst)) -> void {
+	encoding_for_label = label_lookup;
+	utf8_to_utf32 = convert_utf8;
+	encoding_to_utf32 = convert_encoding;
+}
 
 enum class Utf_Error_Handling { ALWAYS_VALID, REPLACE, SKIP };
 
@@ -143,7 +149,7 @@ auto wide_to_utf8(const std::wstring& in) -> std::string
 
 auto utf8_to_wide(const std::string& in, std::wstring& out) -> bool
 {
-	return utf_to_utf_my(in, out);
+	return (*utf8_to_utf32)(in, out);
 }
 auto utf8_to_wide(const std::string& in) -> std::wstring
 {
@@ -477,24 +483,12 @@ auto has_uppercase_at_compound_word_boundary(const std::wstring& word, size_t i)
 
 Encoding_Converter::Encoding_Converter(std::string_view enc_name)
 {
-	auto ptr = reinterpret_cast<const uint8_t*>(enc_name.data());
-	cenc = encoding_for_label_no_replacement(ptr, enc_name.size());
+	cenc = (*encoding_for_label)(enc_name);
 }
 
 auto Encoding_Converter::to_wide(const string& in, wstring& out) -> bool
 {
-	if (cenc == UTF_8_ENCODING)
-		return utf8_to_wide(in, out);
-
-	size_t in_read = in.size();
-	size_t out_written = out.size();
-	auto dec = encoding_new_decoder_without_bom_handling(cenc);
-	auto res = decoder_decode_to_utf16_without_replacement(dec, (const uint8_t*)in.data(), &in_read, (char16_t *)out.data(), &out_written, true);
-	if (res != INPUT_EMPTY) {
-		out.clear();
-		return false;
-	}
-	return true;
+	return (*encoding_to_utf32)(cenc, in, out);
 }
 
 auto Encoding_Converter::to_wide(const string& in) -> wstring

--- a/extensions/spellcheck/nuspell/src/utils.hxx
+++ b/extensions/spellcheck/nuspell/src/utils.hxx
@@ -25,6 +25,7 @@
 #define NUSPELL_UTILS_HXX
 
 #include "structures.hxx"
+#include "dictionary.hxx" // for DLL_PUBLIC
 
 #include <locale>
 #include <clocale>
@@ -38,10 +39,9 @@
 
 namespace nuspell {
 
-// Theese 3 types are declared only for encoding_rs.h
-class Encoding_rs;
-class Encoder;
-class Decoder;
+DLL_PUBLIC auto initialize_portability(const void* (*label_lookup)(std::string_view label),
+                                       bool (*convert_utf8)(std::string_view aSrc, std::wstring& aDst),
+                                       bool (*convert_encoding)(const void* aEncoding, std::string_view aSrc, std::wstring& aDst)) -> void;
 
 auto wide_to_utf8(const std::wstring& in, std::string& out) -> void;
 auto wide_to_utf8(const std::wstring& in) -> std::string;
@@ -107,7 +107,7 @@ auto has_uppercase_at_compound_word_boundary(const std::wstring& word, size_t i)
     -> bool;
 
 class Encoding_Converter {
-	const Encoding_rs* cenc = nullptr;
+	const void* cenc = nullptr;
 
       public:
 	Encoding_Converter() = default;

--- a/layout/build/nsLayoutStatics.cpp
+++ b/layout/build/nsLayoutStatics.cpp
@@ -127,6 +127,7 @@
 #include "nsThreadManager.h"
 #include "mozilla/css/ImageLoader.h"
 #include "gfxUserFontSet.h"
+#include "mozilla/NuspellPortability.h"
 
 using namespace mozilla;
 using namespace mozilla::net;
@@ -144,6 +145,8 @@ nsresult nsLayoutStatics::Initialize() {
                 1);
 
   nsresult rv;
+
+  InitializeNuspellPortability();
 
   ContentParent::StartUp();
 


### PR DESCRIPTION
This compiles on Linux with system Boost. Portability to Windows requires [getting rid of `std::wstring`](https://github.com/nuspell/nuspell/issues/76).